### PR TITLE
set JSON request body encoding to UTF-8 (it was ISO_8859_1 by default)

### DIFF
--- a/src/jszuru/SzurubooruAPI.java
+++ b/src/jszuru/SzurubooruAPI.java
@@ -21,6 +21,7 @@ import org.apache.http.message.BasicNameValuePair;
 import java.io.*;
 import java.lang.reflect.InvocationTargetException;
 import java.net.*;
+import java.nio.charset.StandardCharsets;
 import java.util.*;
 import java.util.regex.Pattern;
 
@@ -217,7 +218,7 @@ public class SzurubooruAPI {
             httpRequest.setHeader("Content", "application/json");
 
             if(body!=null && httpRequest instanceof HttpEntityEnclosingRequest sendRequest){
-                sendRequest.setEntity(new StringEntity(gson.toJson(body)));
+                sendRequest.setEntity(new StringEntity(gson.toJson(body), ContentType.APPLICATION_JSON));
             }
 
             HttpResponse response = httpClient.execute((HttpUriRequest) httpRequest);


### PR DESCRIPTION
per JSON [specification](https://datatracker.ietf.org/doc/html/rfc7159#section-8.1) JSON strings SHALL be encoded in UTF-8 (or other UTF encodings).
the constructor StringEntity(String) uses ISO_8859_1 encoding by default. This mistake leads to the error from szurubooru api: "Could not decode the request body. The JSON was incorrect or was not encoded as UTF-8" if json contains unusual symbols (like ×).

(the latest release does not implement any API that could be broken by this bug, I encountered it with my extended SzurubooruAPI that creates post with pre-defined tags and source:

```
public SzurubooruPost createPost(FileToken content, String safety, List<String> tags, String source) throws IOException, SzurubooruHTTPException, SzurubooruResourceNotSynchronizedException {
            if (!SzurubooruPost.isValidSafety(safety)) {
                throw new IllegalArgumentException("Safety must be of value safe, sketchy or unsafe");
            } else {

                List<Map<String, Object>> tagsMap = tags.stream()
                        .map(this::truncateTag)
                        .map(x -> Map.of("names", (Object) List.of(x)))
                        .toList();
                SzurubooruPost post = new SzurubooruPost(this, new HashMap<>());
                post.setNewJson(Map.of("tags", tagsMap, "safety", safety, "contentToken", content.getToken(),
                        "source", source));
                post.push();
                return post;
            }
        }

        // szurubooru does not accept tags longer than 128 in length
        private String truncateTag(String tag) {
            return tag.length() > 128 ? tag.substring(0, 128) : tag;
        }
```
So, if any tag or the source contains "×", the mentioned error will occur. This commit fixes that.